### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ nntp.connect(function (error, response) {
 
     nntp.overviewFormat(function (error, receivedFormat) {
 
-      nntp.overview(receivedGroup.first + '-' + receivedGroup.first + 100, receivedFormat, function (error, receivedMessages) {
+      nntp.overview(receivedGroup.first + '-' + (parseInt(receivedGroup.first, 10) + 100), receivedFormat, function (error, receivedMessages) {
         console.log(receivedMessages);
       });
     });


### PR DESCRIPTION
The original example went a bit haywire because it tried to do: 
 XOVER 3866433-3866433100
instead of 
 XOVER 3866433-3866533
